### PR TITLE
Revert "Prefer backref when possible"

### DIFF
--- a/fireapi/model/punkttyper.py
+++ b/fireapi/model/punkttyper.py
@@ -41,14 +41,15 @@ class Punkt(FikspunktregisterObjekt):
     __tablename__ = "punkt"
     id = Column(String, nullable=False, unique=True)
     sagseventid = Column(String, ForeignKey("sagsevent.id"), nullable=False)
+    sagsevent = relationship("Sagsevent", back_populates="punkter")
     koordinater = relationship(
-        "Koordinat", order_by="Koordinat.objectid", backref="punkt"
+        "Koordinat", order_by="Koordinat.objectid", back_populates="punkt"
     )
     geometriobjekter = relationship(
-        "GeometriObjekt", order_by="GeometriObjekt.objectid", backref="punkt"
+        "GeometriObjekt", order_by="GeometriObjekt.objectid", back_populates="punkt"
     )
     punktinformationer = relationship(
-        "PunktInformation", order_by="PunktInformation.objectid", backref="punkt"
+        "PunktInformation", order_by="PunktInformation.objectid", back_populates="punkt"
     )
     # TODO: Observationer (Note Observation has three references to Punkt. How to handle this?)
     # Maybe use: "observationer_til" referencing Observation.Sigtepunkt and "observationer_fra" referencing Observation.opstillingspunkt
@@ -67,29 +68,30 @@ class Koordinat(FikspunktregisterObjekt):
     y = Column(Float)
     z = Column(Float)
     sagseventid = Column(String, ForeignKey("sagsevent.id"), nullable=False)
+    sagsevent = relationship("Sagsevent", back_populates="koordinater")
     punktid = Column(String, ForeignKey("punkt.id"), nullable=False)
+    punkt = relationship("Punkt", back_populates="koordinater")
     beregninger = relationship(
-        "Beregning", secondary=beregning_koordinat, back_populates="koordinater"
-    )
+        "Beregning",
+        secondary=beregning_koordinat,
+        back_populates="koordinater")
 
 
 class GeometriObjekt(FikspunktregisterObjekt):
     __tablename__ = "geometriobjekt"
     geometri = Column(columntypes.Point(2, 4326), nullable=False)
     sagseventid = Column(String, ForeignKey("sagsevent.id"), nullable=False)
+    sagsevent = relationship("Sagsevent", back_populates="geometriobjekter")
     punktid = Column(String, ForeignKey("punkt.id"), nullable=False)
-
+    punkt = relationship("Punkt", back_populates="geometriobjekter")
 
 class Beregning(FikspunktregisterObjekt):
     __tablename__ = "beregning"
     objectid = Column(Integer, primary_key=True)
     sagseventid = Column(String, ForeignKey("sagsevent.id"), nullable=False)
-    koordinater = relationship(
-        "Koordinat", secondary=beregning_koordinat, back_populates="beregninger"
-    )
-    observationer = relationship(
-        "Observation", secondary=beregning_observation, back_populates="beregninger"
-    )
+    sagsevent = relationship("Sagsevent", back_populates="beregninger")
+    koordinater = relationship("Koordinat", secondary=beregning_koordinat, back_populates="beregninger")
+    observationer = relationship("Observation", secondary=beregning_observation, back_populates="beregninger")
 
 
 class ObservationType(DeclarativeBase):
@@ -114,7 +116,9 @@ class ObservationType(DeclarativeBase):
     value15 = Column(String)
     sigtepunkt = Column(String, nullable=False)
     observationer = relationship(
-        "Observation", order_by="Observation.objectid", backref="observationstype"
+        "Observation",
+        order_by="Observation.objectid",
+        back_populates="observationstype",
     )
 
 
@@ -137,26 +141,31 @@ class Observation(FikspunktregisterObjekt):
     value14 = Column(Float)
     value15 = Column(Float)
     sagseventid = Column(String, ForeignKey("sagsevent.id"), nullable=False)
+    sagsevent = relationship("Sagsevent", back_populates="observationer")
     observationstidspunkt = Column(DateTime(timezone=True), nullable=False)
     antal = Column(Integer, nullable=False)
     gruppe = Column(Integer)
     observationstypeid = Column(
         "observationstype", String, ForeignKey("observationtype.observationstype")
     )
+    observationstype = relationship("ObservationType", back_populates="observationer")
     sigtepunktid = Column(String, ForeignKey("punkt.id"))
     sigtepunkt = relationship("Punkt", foreign_keys=[sigtepunktid])
     opstillingspunktid = Column(String, ForeignKey("punkt.id"))
     opstillingspunkt = relationship("Punkt", foreign_keys=[opstillingspunktid])
     beregninger = relationship(
-        "Beregning", secondary=beregning_observation, back_populates="observationer"
-    )
+        "Beregning",
+        secondary=beregning_observation,
+        back_populates="observationer")
 
 
 class PunktInformation(FikspunktregisterObjekt):
     __tablename__ = "punktinfo"
     sagseventid = Column(String, ForeignKey("sagsevent.id"), nullable=False)
+    sagsevent = relationship("Sagsevent", back_populates="punktinformationer")
     # TODO: Infotype is foreign key
     infotype = Column(String, nullable=False)
     reeltal = Column(Float)
     tekst = Column(String)
     punktid = Column(String, ForeignKey("punkt.id"), nullable=False)
+    punkt = relationship("Punkt", back_populates="punktinformationer")

--- a/fireapi/model/sagstyper.py
+++ b/fireapi/model/sagstyper.py
@@ -13,9 +13,12 @@ class Sag(RegisteringFraObjekt):
     # TODO: Sagstype is foreign key
     #    sagstype = Column(String, nullable=False)
     id = Column(String, nullable=False)
-    sagsevents = relationship("Sagsevent", order_by="Sagsevent.objectid", backref="sag")
-    sagsinfos = relationship("Sagsinfo", order_by="Sagsinfo.objectid", backref="sag")
-
+    sagsevents = relationship(
+        "Sagsevent", order_by="Sagsevent.objectid", back_populates="sag"
+    )
+    sagsinfos = relationship(
+        "Sagsinfo", order_by="Sagsinfo.objectid", back_populates="sag"
+    )
 
 class Sagsinfo(RegisteringTidObjekt):
     __tablename__ = "sagsinfo"
@@ -25,7 +28,7 @@ class Sagsinfo(RegisteringTidObjekt):
     behandler = Column(String, nullable=False)
     beskrivelse = Column(String)
     sagid = Column(String, ForeignKey("sag.id"), nullable=False)
-
+    sag = relationship("Sag", back_populates="sagsinfos")
 
 class Sagsevent(RegisteringFraObjekt):
     __tablename__ = "sagsevent"
@@ -33,22 +36,27 @@ class Sagsevent(RegisteringFraObjekt):
     event = Column(String, nullable=False)
     # beskrivelse = Column(String)
     sagid = Column(String, ForeignKey("sag.id"), nullable=False)
+    sag = relationship("Sag", back_populates="sagsevents")
     # TODO: Eventtype, materiale, and rapporthtml
     # Fikspunktregisterobjekter
-    punkter = relationship("Punkt", order_by="Punkt.objectid", backref="sagsevent")
+    punkter = relationship(
+        "Punkt", order_by="Punkt.objectid", back_populates="sagsevent"
+    )
     koordinater = relationship(
-        "Koordinat", order_by="Koordinat.objectid", backref="sagsevent"
+        "Koordinat", order_by="Koordinat.objectid", back_populates="sagsevent"
     )
     geometriobjekter = relationship(
-        "GeometriObjekt", order_by="GeometriObjekt.objectid", backref="sagsevent"
+        "GeometriObjekt", order_by="GeometriObjekt.objectid", back_populates="sagsevent"
     )
     observationer = relationship(
-        "Observation", order_by="Observation.objectid", backref="sagsevent"
+        "Observation", order_by="Observation.objectid", back_populates="sagsevent"
     )
     punktinformationer = relationship(
-        "PunktInformation", order_by="PunktInformation.objectid", backref="sagsevent"
+        "PunktInformation",
+        order_by="PunktInformation.objectid",
+        back_populates="sagsevent",
     )
     beregninger = relationship(
-        "Beregning", order_by="Beregning.objectid", backref="sagsevent"
+        "Beregning", order_by="Beregning.objectid", back_populates="sagsevent"
     )
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -87,7 +87,6 @@ def observation(firedb, sagsevent, observationstype, punkt):
     firedb.session.add(o0)
     return o0
 
-
 @pytest.fixture()
 def observationer(firedb, sagsevent, observationstype, punkt):
     o0 = Observation(
@@ -140,9 +139,11 @@ def observationer(firedb, sagsevent, observationstype, punkt):
     firedb.session.add(o1)
     return [o0, o1]
 
-
 @pytest.fixture()
 def beregning(firedb, sagsevent, observationer):
-    b0 = Beregning(sagsevent=sagsevent, observationer=observationer)
+    b0 = Beregning(
+        sagsevent=sagsevent,
+        observationer=observationer
+    )
     firedb.session.add(b0)
     return b0


### PR DESCRIPTION
This reverts commit e24c4c9b3bc7a7ae592eaaa6234669fa40284817 because @AsgerPetersen is right that in this case the implicit is < than the explicit.