### PR TITLE
Unhide id's and rename type accessors

### DIFF
--- a/fireapi/firedb.py
+++ b/fireapi/firedb.py
@@ -162,7 +162,7 @@ class FireDb(object):
 
         """
         srid_filter = str(sridid).upper()
-        return self.session.query(Srid).filter(Srid.srid == srid_filter).one()
+        return self.session.query(Srid).filter(Srid.name == srid_filter).one()
 
     def hent_srider(self, namespace: Optional[str] = None):
         """Gets Srid objects. Optionally filtering by srid namespace
@@ -186,7 +186,7 @@ class FireDb(object):
         typefilter = infotype
         return (
             self.session.query(PunktInformationType)
-            .filter(PunktInformationType.infotype == typefilter)
+            .filter(PunktInformationType.name == typefilter)
             .first()
         )
 
@@ -196,7 +196,7 @@ class FireDb(object):
         like_filter = f"{namespace}:%"
         return (
             self.session.query(PunktInformationType)
-            .filter(PunktInformationType.infotype.ilike(like_filter))
+            .filter(PunktInformationType.name.ilike(like_filter))
             .all()
         )
 
@@ -357,7 +357,7 @@ class FireDb(object):
             [
                 k
                 for k in newkoordinat.punkt.koordinater
-                if str(k.srid.srid) == str(newkoordinat.srid.srid)
+                if str(k.srid.name) == str(newkoordinat.srid.name)
                 and k.registreringtil is None
                 and k is not newkoordinat
             ]

--- a/fireapi/model/punkttyper.py
+++ b/fireapi/model/punkttyper.py
@@ -80,7 +80,7 @@ class PunktInformation(FikspunktregisterObjekt):
     __tablename__ = "punktinfo"
     sagseventid = Column(String(36), ForeignKey("sagsevent.id"), nullable=False)
     sagsevent = relationship("Sagsevent", back_populates="punktinformationer")
-    _infotypeid = Column(
+    infotypeid = Column(
         "infotype", String(4000), ForeignKey("punktinfotype.infotype"), nullable=False
     )
     infotype = relationship("PunktInformationType")
@@ -93,14 +93,14 @@ class PunktInformation(FikspunktregisterObjekt):
 class PunktInformationType(DeclarativeBase):
     __tablename__ = "punktinfotype"
     objectid = Column(Integer, primary_key=True)
-    infotype = Column(String(4000), unique=True, nullable=False)
+    name = Column("infotype", String(4000), unique=True, nullable=False)
     anvendelse = Column(Enum(PunktInformationTypeAnvendelse), nullable=False)
     beskrivelse = Column(String(4000), nullable=False)
 
 
 class Koordinat(FikspunktregisterObjekt):
     __tablename__ = "koordinat"
-    _sridid = Column("srid", String, ForeignKey("sridtype.srid"), nullable=False)
+    sridid = Column("srid", String, ForeignKey("sridtype.srid"), nullable=False)
     srid = relationship("Srid")
     sx = Column(Float)
     sy = Column(Float)
@@ -144,7 +144,7 @@ class Beregning(FikspunktregisterObjekt):
 class ObservationType(DeclarativeBase):
     __tablename__ = "observationtype"
     objectid = Column(Integer, primary_key=True)
-    observationstype = Column(String(4000), nullable=False)
+    name = Column("observationstype", String(4000), nullable=False)
     beskrivelse = Column(String(4000), nullable=False)
     value1 = Column(String, nullable=False)
     value2 = Column(String)
@@ -207,5 +207,5 @@ class Observation(FikspunktregisterObjekt):
 class Srid(DeclarativeBase):
     __tablename__ = "sridtype"
     objectid = Column(Integer, primary_key=True)
-    srid = Column(String(36), nullable=False, unique=True)
+    name = Column("srid", String(36), nullable=False, unique=True)
     beskrivelse = Column(String(4000))

--- a/test/test_punktinformationtype.py
+++ b/test/test_punktinformationtype.py
@@ -4,7 +4,7 @@ from fireapi.model import *
 def test_hent_punktformationtype_by_id(firedb):
     typ = firedb.hent_punktinformationtype("AFM:horisontal")
     assert typ is not None
-    assert typ.infotype == "AFM:horisontal"
+    assert typ.name == "AFM:horisontal"
 
 
 def test_hent_alle_punktinformationtyper(firedb):

--- a/test/test_srid.py
+++ b/test/test_srid.py
@@ -1,4 +1,4 @@
 def test_hent_srid(firedb):
     key = "DK:DVR90"
     srid = firedb.hent_srid(key)
-    assert srid.srid == key
+    assert srid.name == key


### PR DESCRIPTION
E.g. `PunktInfo._infotypeid` -> `PunktInfo._infotypeid` and
`PunktInfoType.infotype` -> `PunktInfoType.name` with the latter being
justified by use cases such as

```
p = firedb.hent_punkt(...)
p.punktinformationer[0].infotype.infotype
```

which rather clumsy. Accessing the infotype as

```
p.punktinformationer[0].infotype.name
``` 
reads much better.

Similar changes has been made to `Srid` and `ObservationsType`.

No idea what the impact on the tests are - will fix if they fail :-)